### PR TITLE
Renamed text specific api's

### DIFF
--- a/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
+++ b/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
@@ -148,17 +148,17 @@ public class RubberStampConfig {
             return this;
         }
 
-        public RubberStampConfigBuilder size(final int size) {
+        public RubberStampConfigBuilder textSize(final int size) {
             this.mSize = size;
             return this;
         }
 
-        public RubberStampConfigBuilder textcolor(final int color) {
+        public RubberStampConfigBuilder textColor(final int color) {
             this.mTextColor = color;
             return this;
         }
 
-        public RubberStampConfigBuilder backgroundcolor(final int color) {
+        public RubberStampConfigBuilder textBackgroundColor(final int color) {
             this.mBackgroundColor = color;
             return this;
         }
@@ -205,7 +205,7 @@ public class RubberStampConfig {
             return this;
         }
 
-        public RubberStampConfigBuilder shadow(final float blurRadius, final float shadowXOffset,
+        public RubberStampConfigBuilder textShadow(final float blurRadius, final float shadowXOffset,
                                         final float shadowYOffset,@ColorInt final int shadowColor) {
             this.mShadowBlurRadius = blurRadius;
             this.mShadowXOffset = shadowXOffset;

--- a/sample/src/main/java/com/vinaygaba/sample/MainActivity.java
+++ b/sample/src/main/java/com/vinaygaba/sample/MainActivity.java
@@ -42,12 +42,12 @@ public class MainActivity extends AppCompatActivity {
 
        RubberStampConfig config = new RubberStampConfigBuilder()
                .base(lenna)
-               .rubberStamp("Watermark")
+               .rubberStamp(logo)
                .alpha(100)
-               .textcolor(Color.BLACK)
-               .backgroundcolor(Color.WHITE)
-               .shadow(0.1f,  5, 5, Color.BLUE)
-               .size(90)
+               .textColor(Color.BLACK)
+               .textBackgroundColor(Color.WHITE)
+               .textShadow(0.1f,  5, 5, Color.BLUE)
+               .textSize(90)
                .rotation(-45)
                .rubberStampPosition(RubberStamp.CENTER)
                .build();


### PR DESCRIPTION
There were a number of text RubberStamp only api's but their names didn't suggest that. This PR fixes that by renaming some API's and fixing some typos