### PR TITLE
Added example to add stamp on background thread

### DIFF
--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -22,5 +22,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.3.0'
+    compile 'io.reactivex:rxjava:1.1.6'
+    compile 'io.reactivex:rxandroid:1.2.1'
     compile project(':library')
 }


### PR DESCRIPTION
I feel it makes sense to leave it up to the developer to call the addStamp method on a background thread. It is really trivial to do that using RxJava. The sample app now does that on the background thread. Should close #18 