### PR TITLE
Added custom position to be a part of the same API

### DIFF
--- a/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
+++ b/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
@@ -172,11 +172,11 @@ public class RubberStampConfig {
                                                                     int position,
                                                             final int positionX,
                                                             final int positionY) {
-            this.mRubberStampPosition = position;
-            if (mRubberStampPosition != RubberStamp.CUSTOM) {
+            if (position != RubberStamp.CUSTOM) {
                 throw new IllegalArgumentException("This constructor can only be used when the " +
                         "rubberStampPosition is RubberStamp.CUSTOM");
             }
+            this.mRubberStampPosition = position;
             this.mPositionX = positionX;
             this.mPositionY = positionY;
             return this;


### PR DESCRIPTION
It made sense to have this as part of the same method call instead of passing it as a separate method. Also enforce the use of this constructor only when the position passed to it is RubberStamp.Custom.