### PR TITLE
Added ability to specify margin

### DIFF
--- a/library/src/main/java/com/vinaygaba/rubberstamp/RubberStamp.java
+++ b/library/src/main/java/com/vinaygaba/rubberstamp/RubberStamp.java
@@ -127,6 +127,8 @@ public class RubberStamp {
             positionY = pair.second;
         }
 
+        positionX += config.getXMargin();
+        positionY += config.getYMargin();
 
         float rotation = config.getRotation();
         if (rotation != 0.0f) {
@@ -189,6 +191,9 @@ public class RubberStamp {
             positionX = pair.first;
             positionY = pair.second - rubberStampBitmap.getHeight();
         }
+
+        positionX += config.getXMargin();
+        positionY += config.getYMargin();
 
         float rotation = config.getRotation();
         if (rotation != 0.0f) {

--- a/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
+++ b/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
@@ -25,6 +25,7 @@ public class RubberStampConfig {
     private int mPositionX, mPositionY;
     private float mTextShadowBlurRadius, mTextShadowXOffset, mTextShadowYOffset;
     private int mTextShadowColor;
+    private int mXMargin, mYMargin;
 
     private RubberStampConfig(RubberStampConfigBuilder builder) {
         this.mBaseBitmap = builder.mBaseBitmap;
@@ -45,6 +46,8 @@ public class RubberStampConfig {
         this.mTextShadowXOffset = builder.mTextShadowXOffset;
         this.mTextShadowYOffset = builder.mTextShadowYOffset;
         this.mTextShadowBlurRadius = builder.mTextShadowBlurRadius;
+        this.mXMargin = builder.mXMargin;
+        this.mYMargin = builder.mYMargin;
     }
   
     public Bitmap getBaseBitmap() {
@@ -119,6 +122,14 @@ public class RubberStampConfig {
         return mTextShadowColor;
     }
 
+    public int getXMargin() {
+        return mXMargin;
+    }
+
+    public int getYMargin() {
+        return mYMargin;
+    }
+
     public static class RubberStampConfigBuilder {
 
         private Bitmap mBaseBitmap;
@@ -136,6 +147,7 @@ public class RubberStampConfig {
         private int mPositionX, mPositionY;
         private float mTextShadowBlurRadius, mTextShadowXOffset, mTextShadowYOffset;
         @ColorInt private int mTextShadowColor = Color.WHITE;
+        private int mXMargin, mYMargin;
 
         public RubberStampConfigBuilder base(final Bitmap bitmap) {
             this.mBaseBitmap = bitmap;
@@ -216,6 +228,12 @@ public class RubberStampConfig {
             this.mTextShadowXOffset = shadowXOffset;
             this.mTextShadowYOffset = shadowYOffset;
             this.mTextShadowColor = shadowColor;
+            return this;
+        }
+
+        public RubberStampConfigBuilder margin(final int xMargin, final int yMargin) {
+            this.mXMargin = xMargin;
+            this.mYMargin = yMargin;
             return this;
         }
 


### PR DESCRIPTION
This PR addresses #31. Added ability to specify margin for the rubber stamp. The positions are applied on the x and y coordinates. It accepts negative margins as well to move the rubberstamp in the negative x and y direction.