### PR TITLE
Rename textfont API

### DIFF
--- a/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
+++ b/library/src/main/java/com/vinaygaba/rubberstamp/RubberStampConfig.java
@@ -174,7 +174,7 @@ public class RubberStampConfig {
             return this;
         }
 
-        public RubberStampConfigBuilder typeFacePath(final String typeFacePath) {
+        public RubberStampConfigBuilder textFont(final String typeFacePath) {
             this.mTypeFacePath = typeFacePath;
             return this;
         }

--- a/sample/src/main/java/com/vinaygaba/sample/MainActivity.java
+++ b/sample/src/main/java/com/vinaygaba/sample/MainActivity.java
@@ -177,7 +177,7 @@ public class MainActivity extends AppCompatActivity {
                     .textColor(mTextColorValue)
                     .textBackgroundColor(mTextBackgroundColorValue)
                     .textShader(shader)
-                    .typeFacePath(path)
+                    .textFont(path)
                     .textSize(mTextSizeSeekBar.getProgress())
                     .build();
         }


### PR DESCRIPTION
The previous method name for passing text font was unintuitive so renamed it. 